### PR TITLE
design: 모달 창 및 일정 클릭 시 디자인 변경

### DIFF
--- a/app/src/main/java/com/apptive/myapplication/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -69,8 +70,10 @@ fun HomeTab(modifier: Modifier = Modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = Color.White, shape = RoundedCornerShape(16.dp)) //모서리가 둥글게 하기 위함
-                .border(width = 1.dp, color = Color.LightGray, shape = RoundedCornerShape(12.dp))
+                .shadow(elevation = 3.dp, shape = RoundedCornerShape(16.dp))
+                // 테두리색 지정보다는 다른 페이지와의 통일감을 위해 그림자로 변경
+                .background(color = Color.White, shape = RoundedCornerShape(16.dp))
+                //RoundedCornerShape: 모서리가 둥글게 하기 위함. size 숫자 클수록 더 둥글둥글해짐
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -81,7 +84,7 @@ fun HomeTab(modifier: Modifier = Modifier) {
                 modifier = Modifier.padding(bottom = 4.dp)
             )
 
-            //상태 리스트를 기반으로 HabitList를 동적으로 생성하고, 클릭 이벤트 처리
+            // 상태 리스트를 기반으로 HabitList를 동적으로 생성하고, 클릭 이벤트 처리
             // '동적' 이란 말의 의미: 고정되지 않음
             habits.forEachIndexed { index, habit ->
                 HabitList(

--- a/app/src/main/java/com/apptive/myapplication/ui/home/components/AddHabit.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/components/AddHabit.kt
@@ -2,13 +2,18 @@ package com.apptive.myapplication.ui.home.components
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun AddHabit(onDismiss: () -> Unit, onAdd: (String) -> Unit) {
@@ -22,27 +27,46 @@ fun AddHabit(onDismiss: () -> Unit, onAdd: (String) -> Unit) {
         onDismissRequest = onDismiss,
         // 다이얼로그 닫기 요청 처리: 사용자가 다이얼로그 바깥 영역을 클릭했을 때 호출
         // ->> 외부에서 showDialog = false를 전달받았을 때
-        title = { Text("새로운 습관 추가") },
+        containerColor = Color.White, // 모달 배경색
+        title = { Text("새로운 습관 추가", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = Color.Gray)},
         text = {
             TextField( //사용자가 새로운 습관의 내용을 직접 입력하는 공간
                 value = text,
                 onValueChange = { text = it },
                 // onValueChange: 사용자가 키보드를 입력할 때마다 호출 -> text 상태 변수의 값을 최신 입력값으로 업데이트
                 label = { Text("습관 내용") },
-                singleLine = true
+                singleLine = true,
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color(0xFFDC2626),
+                    // 사용자가 TextField를 터치하여 키보드가 활성화되었을 때, 하단 밑줄의 색상
+                    unfocusedIndicatorColor = Color.LightGray,
+                    // TextField가 비활성화 상태일 때, 하단 밑줄의 색상
+                    focusedContainerColor = Color.White,
+                    // 사용자가 TextField를 터치하여 키보드가 활성화되었을 때, 배경 채우기의 색상
+                    unfocusedContainerColor = Color.White,
+                    // TextField가 비활성화 상태일 때, 배경 채우기의 색상
+                    focusedLabelColor = Color(0xFFDC2626),
+                    // 사용자가 TextField를 터치하여 키보드가 활성화되었을 때, label(습관 내용)의 색상
+                    unfocusedLabelColor = Color.Gray
+                    // TextField가 비활성화 상태일 때, label(습관 내용)의 색상
+                )
             )
         },
         confirmButton = {
             // 클릭 시 외부에서 전달받은 onAdd 람다 함수를 호출
             // 현재 TextField에 입력된 text 값을 파라미터로 넘겨줌
             // HomeTab에서는 이 값을 받아 habits 목록에 추가함
-            Button(onClick = { onAdd(text) }) {
+            Button(onClick = { onAdd(text) },
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFDC2626))
+            ) {
                 Text("추가")
             }
         },
         dismissButton = {
             // 클릭 시 다이얼로그 닫기 요청과 동일하게 onDismiss 람다 함수를 호출하여 다이얼로그를 닫음.
-            Button(onClick = onDismiss) {
+            Button(onClick = onDismiss,
+                colors = ButtonDefaults.buttonColors(containerColor = Color.LightGray)
+            ) {
                 Text("취소")
             }
         }

--- a/app/src/main/java/com/apptive/myapplication/ui/home/components/AddHabitButton.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/components/AddHabitButton.kt
@@ -34,7 +34,7 @@ fun AddHabitButton(onClick: () -> Unit) { // +새로운 습관 추가 버튼 ui 
             // 함수 parameter : onClick -> 외부에서 showDialog = true 를 전달받았을 때 실행되도록 함
             .drawBehind {// 표준 border Modifier가 점선을 지원하지 않음 -> var stroke 정의하여 스타일 적용시킴
                 drawRoundRect(
-                    color = Color.LightGray,
+                    color = Color.Gray,
                     style = stroke,
                     cornerRadius = CornerRadius(8.dp.toPx()) // 모서리 둥글게
                 )

--- a/app/src/main/java/com/apptive/myapplication/ui/home/components/HabitList.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/components/HabitList.kt
@@ -1,5 +1,6 @@
 package com.apptive.myapplication.ui.home.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
@@ -18,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -32,6 +34,8 @@ fun HabitList(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            // 클릭했을 때 배경색이 사각형이 아닌 둥근 모서리로 채워지려면 클릭 효과가 적용될 영역을 먼저 둥글게 잘라내야 함(clip)
             .clickable(onClick = onHabitClick) // Row 전체에 클릭 이벤트 적용
             .border(
                 width = 1.dp, //테두리 두께
@@ -53,14 +57,17 @@ fun HabitList(
 
         Spacer(modifier = Modifier.width(12.dp)) //아이콘과 텍스트 사이에 12.dp만큼의 가로 간격
 
-        //isDone 상태에 따라 텍스트 색상과 취소선을 변경
-        val textColor = if (habit.isDone) Color.Gray else Color.Black
-        val textDecoration = if (habit.isDone) TextDecoration.LineThrough else TextDecoration.None
+        //isDone 상태에 따라 텍스트 색상과 배경색을 변경
+
+        val textBackground = if (habit.isDone) Color(0x20B31B1B) else Color.Transparent
+        // default : 색 채우기 투명 -> isDone: 색 채우기 핑크
         Text(
             text = habit.text,
+            modifier = Modifier.background(textBackground, shape = RoundedCornerShape(6.dp)),
+            // isDone 상태에 따라 색 채우기 변경
             fontSize = 12.sp,
-            color = textColor,
-            textDecoration = textDecoration
+            color = if (habit.isDone) Color.Gray else Color.Black
+            // default : 글자색 검은색 -> isDone: 글자색 검정
         )
     }
 }


### PR DESCRIPTION
- [ ] 오늘의 습관 : 다른 페이지와의 통일감을 위해 테두리에서 그림자로 변경

- [ ] 모달 디자인 변경
	- 모달 배경색 흰색
	- TextField
		- 비활성화 상태: 하단 밑줄 연회색 / 배경 흰색 / label 회색
		- 사용자가 TextField를 터치했을 때(활성화 상태): 하단 밑줄 빨간색 / 배경 흰색 / label 빨간색
	- 추가 버튼 빨간색 / 취소버튼 연회색
- [ ] 새로운 습관 추가 버튼 점선 테두리 색상 변경(연회색 -> 회색)

- [ ] 일정 클릭했을 때 배경색이 둥근 모서리가 아니라서 변경
- [ ] isDone 상태일 때의 디자인 변경 : 취소선 -> 배경 핑크색

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/7901e29e-a4c8-4a49-a1ef-c044c29be5b4" />
&nbsp;&nbsp;
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/018af5c8-ce37-440b-8a81-81abeef96fdc" />

