### PR TITLE
refactor: Viewmodel 사용하도록 홈탭 수정

### DIFF
--- a/app/src/main/java/com/apptive/myapplication/PodomoroApp.kt
+++ b/app/src/main/java/com/apptive/myapplication/PodomoroApp.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.apptive.myapplication.navigation.PodomoroDestination
 import com.apptive.myapplication.navigation.PodomoroNavGraph
+import com.apptive.myapplication.viewmodel.MainViewModel
 
 private data class BottomNavItem(
     val destination: PodomoroDestination,
@@ -37,6 +39,7 @@ private val bottomNavItems = listOf(
 @androidx.compose.runtime.Composable
 fun PodomoroApp() {
     val navController = rememberNavController()
+    val mainViewModel: MainViewModel = viewModel()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
@@ -104,6 +107,7 @@ fun PodomoroApp() {
     ) { innerPadding ->
         PodomoroNavGraph(
             navController = navController,
+            mainViewModel = mainViewModel,
             modifier = Modifier.padding(innerPadding)
         )
     }

--- a/app/src/main/java/com/apptive/myapplication/model/Habit.kt
+++ b/app/src/main/java/com/apptive/myapplication/model/Habit.kt
@@ -3,7 +3,7 @@ import java.time.LocalDate
 data class Habit(
     val id: Int,
     val name: String,
-    val completionDates: MutableList<LocalDate> = mutableListOf()
+    val completionDates: List<LocalDate> = emptyList()
 ) {
     //HomeScreen의 text 속성을 name을 통해 접근
     val text: String

--- a/app/src/main/java/com/apptive/myapplication/model/Habit.kt
+++ b/app/src/main/java/com/apptive/myapplication/model/Habit.kt
@@ -1,3 +1,16 @@
 package com.apptive.myapplication.model
+import java.time.LocalDate
+data class Habit(
+    val id: Int,
+    val name: String,
+    val completionDates: MutableList<LocalDate> = mutableListOf()
+) {
+    //HomeScreen의 text 속성을 name을 통해 접근
+    val text: String
+        get() = name
 
-data class Habit(val text: String, var isDone: Boolean = false)
+    //isDone 대신 isCompletedOn
+    fun isCompletedOn(date: LocalDate): Boolean {
+        return completionDates.contains(date)
+    }
+}

--- a/app/src/main/java/com/apptive/myapplication/navigation/PodomoroNavGraph.kt
+++ b/app/src/main/java/com/apptive/myapplication/navigation/PodomoroNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import com.apptive.myapplication.ui.home.HomeTab
 import com.apptive.myapplication.ui.stats.StatsTab
 import com.apptive.myapplication.ui.timer.TimerTab
+import com.apptive.myapplication.viewmodel.MainViewModel
 
 enum class PodomoroDestination(val route: String, val title: String) {
     Home("home", "홈"),
@@ -18,6 +19,7 @@ enum class PodomoroDestination(val route: String, val title: String) {
 @Composable
 fun PodomoroNavGraph(
     navController: NavHostController,
+    mainViewModel: MainViewModel,
     modifier: Modifier = Modifier
 ) {
     NavHost(
@@ -26,13 +28,13 @@ fun PodomoroNavGraph(
         modifier = modifier
     ) {
         composable(route = PodomoroDestination.Home.route) {
-            HomeTab()
+            HomeTab(viewModel = mainViewModel)
         }
         composable(route = PodomoroDestination.Timer.route) {
             TimerTab()
         }
         composable(route = PodomoroDestination.Stats.route) {
-            StatsTab()
+            StatsTab(viewModel = mainViewModel)
         }
     }
 }

--- a/app/src/main/java/com/apptive/myapplication/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.apptive.myapplication.ui.home
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -23,25 +21,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-
-//code refactoring
 import com.apptive.myapplication.ui.home.components.AddHabitButton
 import com.apptive.myapplication.ui.home.components.AddHabit
 import com.apptive.myapplication.ui.home.components.HabitList
-//data class를 model/Habit로 이동함
-import com.apptive.myapplication.model.Habit
+import com.apptive.myapplication.viewmodel.MainViewModel
 
 @Composable
-fun HomeTab(modifier: Modifier = Modifier) {
+fun HomeTab(modifier: Modifier = Modifier
+, viewModel: MainViewModel = viewModel()
+) {
     // 날짜를 현재 시간 기준으로 표현하기 위한 변수들
     val currentDate = LocalDate.now()
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
     val formattedDate = currentDate.format(formatter)
 
-    // 습관 목록을 Habit 객체로 관리하도록 수정
-    val habits = remember { mutableStateListOf<Habit>() }
     // 다이얼로그(팝업창) 표시 여부를 관리하기 위한 상태
     var showDialog by remember { mutableStateOf(false) }
 
@@ -84,14 +80,11 @@ fun HomeTab(modifier: Modifier = Modifier) {
                 modifier = Modifier.padding(bottom = 4.dp)
             )
 
-            // 상태 리스트를 기반으로 HabitList를 동적으로 생성하고, 클릭 이벤트 처리
-            // '동적' 이란 말의 의미: 고정되지 않음
-            habits.forEachIndexed { index, habit ->
+            viewModel.habits.forEach { habit ->
                 HabitList(
                     habit = habit,
                     onHabitClick = {
-                        // 클릭된 항목의 isDone 상태를 반전시킴
-                        habits[index] = habit.copy(isDone = !habit.isDone)
+                        viewModel.toggleHabit(habit)
                     }
                 )
             }
@@ -102,8 +95,7 @@ fun HomeTab(modifier: Modifier = Modifier) {
         // 새로운 습관 추가 버튼
         AddHabitButton(onClick = { showDialog = true })
 
-        // 새로운 습관을 추가하는 다이얼로그를 언제, 어떻게 보여줄지를 결정
-        // *참고 : 다이얼로그(Dialog)는 현재 화면 위에 작게 나타나는 별도의 창(팝업창)을 의미
+        // 새로운 습관을 추가하는 다이얼로그
         if (showDialog) {
             // '새로운 습관 추가하기' 버튼(AddHabitButton)을 누르면 onClick = { showDialog = true } 코드가 실행
             // -> AddHbit 함수 호출 -> '새로운 습관 추가' 다이얼로그의 모양과 기능을 정의
@@ -112,9 +104,7 @@ fun HomeTab(modifier: Modifier = Modifier) {
                 //사용자가 다이얼로그 바깥쪽을 클릭하거나, '취소' 버튼을 누르면 onDismiss = { showDialog = false } 코드가 실행됨
                 onAdd = { newHabitText ->
                     // onAdd는 사용자가 다이얼로그에서 '추가' 버튼을 눌렀을 때 무엇을 할 것인지 정의함
-                    if (newHabitText.isNotBlank()) { //입력된 내용이 비어있지 않은지 확인
-                        habits.add(Habit(newHabitText)) // 4. Habit 객체로 리스트에 추가
-                    }
+                    viewModel.addHabit(newHabitText)
                     showDialog = false
                     // 습관을 추가한 후, 다이얼로그를 닫기 위해 showDialog를 false로 변경
                 }

--- a/app/src/main/java/com/apptive/myapplication/ui/home/components/HabitList.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/home/components/HabitList.kt
@@ -25,12 +25,15 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.apptive.myapplication.model.Habit
+import java.time.LocalDate
 
 @Composable
 fun HabitList(
     habit: Habit, // String 대신 Habit 객체를 받음
     onHabitClick: () -> Unit // 클릭 이벤트를 상위로 전달
 ) { // 하나의 습관 항목을 화면에 어떻게 나타낼지 정의
+    val isCompleted = habit.isCompletedOn(LocalDate.now())
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -46,9 +49,9 @@ fun HabitList(
             .padding(horizontal = 12.dp, vertical = 8.dp), // 테두리 안 여백 정의 : 좌우 12.dp, 위아래: 8.dp
         verticalAlignment = Alignment.CenterVertically // contents를 수직 방향으로 가운데 정렬
     ) {
-        // isDone 상태에 따라 아이콘과 색상을 변경
-        val icon = if (habit.isDone) Icons.Filled.CheckCircle else Icons.Default.RadioButtonUnchecked
-        val iconColor = if (habit.isDone) Color.Red else Color.LightGray
+        // isCompleted 상태에 따라 아이콘과 색상을 변경
+        val icon = if (isCompleted) Icons.Filled.CheckCircle else Icons.Default.RadioButtonUnchecked
+        val iconColor = if (isCompleted) Color.Red else Color.LightGray
         Icon(
             imageVector = icon,
             contentDescription = "Habit status",
@@ -59,14 +62,14 @@ fun HabitList(
 
         //isDone 상태에 따라 텍스트 색상과 배경색을 변경
 
-        val textBackground = if (habit.isDone) Color(0x20B31B1B) else Color.Transparent
+        val textBackground = if (isCompleted) Color(0x20B31B1B) else Color.Transparent
         // default : 색 채우기 투명 -> isDone: 색 채우기 핑크
         Text(
             text = habit.text,
             modifier = Modifier.background(textBackground, shape = RoundedCornerShape(6.dp)),
             // isDone 상태에 따라 색 채우기 변경
             fontSize = 12.sp,
-            color = if (habit.isDone) Color.Gray else Color.Black
+            color = if (isCompleted) Color.Gray else Color.Black
             // default : 글자색 검은색 -> isDone: 글자색 검정
         )
     }

--- a/app/src/main/java/com/apptive/myapplication/ui/timer/TimerScreen.kt
+++ b/app/src/main/java/com/apptive/myapplication/ui/timer/TimerScreen.kt
@@ -1,13 +1,22 @@
 package com.apptive.myapplication.ui.timer
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,7 +66,7 @@ fun TimerTab() {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(color = Color(0xFFE5E7EB))
+            .background(color = Color.White)
             .verticalScroll(scrollState) // 스크롤 가능하게 설정
             .padding(16.dp)
     ) {
@@ -98,8 +107,11 @@ fun TimerTab() {
                         timeLeft--
                     }
                     isStarted = !isStarted
-                                    },
-                onReset = { isStarted = false; isWorking = true; timeLeft = if (is50minMode) 50 * 60 else 30 * 60 }
+                },
+                onReset = {
+                    isStarted = false; isWorking = true; timeLeft =
+                    if (is50minMode) 50 * 60 else 30 * 60
+                }
             )
 
         }

--- a/app/src/main/java/com/apptive/myapplication/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/apptive/myapplication/viewmodel/MainViewModel.kt
@@ -22,10 +22,15 @@ class MainViewModel : ViewModel() {
 
     fun toggleHabit(habit: Habit) {
         val today = LocalDate.now()
-        if (habit.isCompletedOn(today)) {
-            habit.completionDates.remove(today)
+        val updatedDates = if (habit.isCompletedOn(today)) {
+            habit.completionDates - today
         } else {
-            habit.completionDates.add(today)
+            habit.completionDates + today
+        }
+
+        val habitIndex = habits.indexOfFirst { it.id == habit.id }
+        if (habitIndex != -1) {
+            habits[habitIndex] = habit.copy(completionDates = updatedDates)
         }
     }
 }


### PR DESCRIPTION
홈탭에서 `remember` 대신 MainViewModel의 데이터를 사용하도록 코드 수정했습니다

- 습관 목록
	 `remember { mutableStateListOf<Habit>() }` ->`viewModel.habits`
- 습관 추가 
	`viewModel.addHabit()` 호출
- 습관 완료/취소
	`viewModel.toggleHabit()` 호출
